### PR TITLE
Add plugin for MCP server generator

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ members = [
     "cmd/crates/soroban-test/tests/fixtures/test-wasms/*",
     "cmd/crates/soroban-test/tests/fixtures/hello",
     "cmd/crates/soroban-test/tests/fixtures/bye"
+    ,"cmd/plugins/stellar-mcp-server"
 ]
 default-members = [
     "cmd/soroban-cli",

--- a/Makefile
+++ b/Makefile
@@ -32,6 +32,7 @@ install:
 	cargo install --force --locked --path ./cmd/stellar-cli --debug
 	cargo install --force --locked --path ./cmd/crates/soroban-test/tests/fixtures/hello --root ./target --debug --quiet
 	cargo install --force --locked --path ./cmd/crates/soroban-test/tests/fixtures/bye --root ./target --debug --quiet
+	cargo install --force --locked --path ./cmd/plugins/stellar-mcp-server --root ./target --debug --quiet
 
 # regenerate the example lib in `cmd/crates/soroban-spec-typsecript/fixtures/ts`
 build-snapshot: typescript-bindings-fixtures

--- a/cmd/plugins/stellar-mcp-server/Cargo.toml
+++ b/cmd/plugins/stellar-mcp-server/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "stellar-mcp-server"
+version.workspace = true
+edition = "2021"
+publish = false
+
+[dependencies]
+soroban-cli = { path = "../../soroban-cli" }
+clap = { workspace = true, features = ["derive", "env", "deprecated", "string"] }
+tokio = { version = "1", features = ["full"] }

--- a/cmd/plugins/stellar-mcp-server/src/main.rs
+++ b/cmd/plugins/stellar-mcp-server/src/main.rs
@@ -1,0 +1,17 @@
+use clap::Parser;
+use soroban_cli::commands::{contract::bindings::mcp_server, global};
+
+#[derive(Parser, Debug)]
+#[command(name = "stellar-mcp-server")]
+struct Cli {
+    #[command(flatten)]
+    global: global::Args,
+    #[command(flatten)]
+    cmd: mcp_server::Cmd,
+}
+
+#[tokio::main]
+async fn main() -> Result<(), mcp_server::Error> {
+    let cli = Cli::parse();
+    cli.cmd.run(Some(&cli.global)).await
+}

--- a/cmd/soroban-cli/src/commands/contract/bindings.rs
+++ b/cmd/soroban-cli/src/commands/contract/bindings.rs
@@ -1,9 +1,9 @@
 pub mod java;
 pub mod json;
+pub mod mcp_server;
 pub mod python;
 pub mod rust;
 pub mod typescript;
-pub mod mcp_server;
 
 use crate::commands::global;
 
@@ -23,9 +23,6 @@ pub enum Cmd {
 
     /// Generate Java bindings
     Java(java::Cmd),
-
-    /// Generate MCP Server bindings
-    McpServer(Box<mcp_server::Cmd>),
 }
 
 #[derive(thiserror::Error, Debug)]
@@ -44,9 +41,6 @@ pub enum Error {
 
     #[error(transparent)]
     Java(#[from] java::Error),
-
-    #[error(transparent)]
-    McpServer(#[from] mcp_server::Error),
 }
 
 impl Cmd {
@@ -57,7 +51,6 @@ impl Cmd {
             Cmd::Typescript(ts) => ts.run().await?,
             Cmd::Python(python) => python.run()?,
             Cmd::Java(java) => java.run()?,
-            Cmd::McpServer(mcp) => mcp.run(global_args).await?,
         }
         Ok(())
     }


### PR DESCRIPTION
## Summary
- remove built‐in `mcp-server` subcommand
- add new `stellar-mcp-server` plugin crate
- install plugin during `make install`
- register plugin crate in workspace

## Testing
- `cargo check -p stellar-mcp-server` *(fails: failed to download from `https://index.crates.io/config.json`)*

------
https://chatgpt.com/codex/tasks/task_e_686c4c1d886c832ca9b74377b4317912